### PR TITLE
Vendor IDs for CompuLife and DeciSense

### DIFF
--- a/DIP_vendors.json
+++ b/DIP_vendors.json
@@ -75,6 +75,14 @@
         "0x4b363134":{
             "contact":"chip@kodachi.com",
             "vendor":"Kodachi 6*14, LLC"
+        },
+        "0x78600000":{
+            "contact":"kashif@compulife.com.pk",
+            "vendor":"CompuLife, Pakistan"
+        },
+        "0x78678600":{
+            "contact":"kashif@compulife.com.pk",
+            "vendor":"DeciSense"
         }
     }
 }


### PR DESCRIPTION
Added Vendor IDs for CompuLife, Pakistan (for general DIPs) and DeciSense (for home and industrial automation related DIPs)